### PR TITLE
fixed no-gpu bug

### DIFF
--- a/assets/cloud-config-no-gpu.yaml
+++ b/assets/cloud-config-no-gpu.yaml
@@ -1,0 +1,50 @@
+#cloud-config
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+write_files:
+- path: /etc/systemd/system/fah.service
+  permissions: 0644
+  owner: root
+  content: |
+    [Unit]
+    Description=Folding at Home service
+    Requires=gcr-online.target
+    After=gcr-online.target
+
+    [Service]
+    User=root
+    ExecStart=/usr/bin/docker run \
+      --name=fah \
+      -p 7396:7396 \
+      --restart always \
+      ${fah_worker_image} \
+      --user=${fah_user_name} ${fah_passkey != "" ? "--passkey=${fah_passkey} " : "" }\
+      --team=${fah_team_id} \
+      --power=full \
+      --cpu-usage=100 \
+      --gpu=false
+    ExecStop=/usr/bin/docker stop fah
+    ExecStopPost=/usr/bin/docker rm fah
+    StandardOutput=journal+console
+    StandardError=journal+console
+
+    [Install]
+    WantedBy=multi-user.target
+
+runcmd:
+  - systemctl daemon-reload
+  - systemctl enable fah.service
+  - systemctl start fah.service

--- a/compute.tf
+++ b/compute.tf
@@ -21,14 +21,17 @@ data "google_compute_image" "image" {
 }
 
 data "template_file" "cloud-config" {
-  template = file("${path.module}/assets/cloud-config.yaml")
-
   vars = {
     fah_worker_image = var.fah_worker_image
     fah_user_name = var.fah_user_name
     fah_passkey = var.fah_passkey
     fah_team_id = var.fah_team_id
+    fah_worker_gpu = var.fah_worker_gpu
   }
+
+  template = var.fah_worker_gpu != "" ? file("${path.module}/assets/cloud-config.yaml") : file("${path.module}/assets/cloud-config-no-gpu.yaml")
+
+  
 }
 
 ####

--- a/compute.tf
+++ b/compute.tf
@@ -26,7 +26,6 @@ data "template_file" "cloud-config" {
     fah_user_name = var.fah_user_name
     fah_passkey = var.fah_passkey
     fah_team_id = var.fah_team_id
-    fah_worker_gpu = var.fah_worker_gpu
   }
 
   template = var.fah_worker_gpu != "" ? file("${path.module}/assets/cloud-config.yaml") : file("${path.module}/assets/cloud-config-no-gpu.yaml")


### PR DESCRIPTION
Fixes #3 

Added a brand new `cloud-config-no-gpu.yaml` file that eliminates the unnecessary installs of video card drivers when no gpus are present

Test: 
1. create a new terraform project
2. specify fah_worker_gpu = "" in terraform.tfvars
3. wait and checkout docker ps logs
4. you should be able to see fahclient running, can also verify with `top`